### PR TITLE
Transaction items

### DIFF
--- a/cli/src/output/table/transactions.rs
+++ b/cli/src/output/table/transactions.rs
@@ -14,6 +14,18 @@ pub struct TransactionsTable {
     pub disc_income: MonthValues,
 }
 
+impl TransactionsTable {
+    fn fmt_description(&self, description: &String) -> String {
+        description
+            .chars()
+            .take(60)
+            .collect::<String>()
+            .split_whitespace()
+            .collect::<Vec<&str>>()
+            .join(" ")
+    }
+}
+
 impl ToTable<ValueTable> for TransactionsTable {
     fn to_table(&self, opts: OutputOptions) -> ValueTable {
         let mut table = ValueTable::new(
@@ -34,16 +46,7 @@ impl ToTable<ValueTable> for TransactionsTable {
         for transaction in transactions.iter().take(10) {
             table.add_row(&[
                 Cell::Text(transaction.date.format("%Y/%m/%d").to_string()),
-                Cell::Text(
-                    transaction
-                        .description
-                        .chars()
-                        .take(60)
-                        .collect::<String>()
-                        .split_whitespace()
-                        .collect::<Vec<&str>>()
-                        .join(" "),
-                ),
+                Cell::Text(self.fmt_description(&transaction.description)),
                 Cell::Value(transaction.amount * -1.0),
                 Cell::Text(transaction.tag.to_owned().unwrap_or_default()),
                 match self
@@ -58,6 +61,16 @@ impl ToTable<ValueTable> for TransactionsTable {
                     None => Cell::Text("".into()),
                 },
             ]);
+
+            for item in &transaction.items {
+                table.add_row(&[
+                    Cell::Text(Default::default()),
+                    Cell::Text(format!("-> {}", self.fmt_description(&item.description))),
+                    Cell::Value(item.amount * -1.0),
+                    Cell::Text(Default::default()),
+                    Cell::Text(Default::default()),
+                ])
+            }
         }
 
         table

--- a/convert/src/input/camt053.rs
+++ b/convert/src/input/camt053.rs
@@ -43,6 +43,7 @@ impl Camt053Input {
                     account_id: AccountId::Iban(
                         statement.account.id.value.as_str_id().into(),
                     ),
+                    items: Vec::new(),
                 })
             })
             .collect()

--- a/lib/src/statements/rule/action_opts.rs
+++ b/lib/src/statements/rule/action_opts.rs
@@ -23,4 +23,8 @@ pub enum Action {
     ApplyTag {
         tag: String,
     },
+    #[cfg(feature = "transaction")]
+    AddItems {
+        items: Vec<crate::statements::transaction::TransactionItem>,
+    },
 }

--- a/lib/src/statements/savings/context.rs
+++ b/lib/src/statements/savings/context.rs
@@ -40,7 +40,7 @@ impl Context for SavingsContext {
                 let savings_progress: f32 = self
                     .savings
                     .iter()
-                    .filter(|savings: &&Savings| savings.goal == goal.id)
+                    .filter(|savings: &&Savings| savings.goal == Some(goal.id.to_owned()))
                     .map(|savings: &Savings| savings.get_total_amount(self.now))
                     .sum();
 

--- a/lib/src/statements/savings/mod.rs
+++ b/lib/src/statements/savings/mod.rs
@@ -11,7 +11,8 @@ pub struct Savings {
     #[serde(flatten)]
     pub model: SavingsModel,
     pub amount: f32,
-    pub goal: String,
+    #[cfg(feature = "goal")]
+    pub goal: Option<String>,
 }
 
 impl Savings {

--- a/lib/src/statements/transaction/mod.rs
+++ b/lib/src/statements/transaction/mod.rs
@@ -13,4 +13,12 @@ pub struct Transaction {
     pub date: NaiveDateTime,
     pub amount: f32,
     pub account_id: AccountId,
+    #[serde(default)]
+    pub items: Vec<TransactionItem>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct TransactionItem {
+    pub description: String,
+    pub amount: f32,
 }

--- a/lib/src/statements/transaction/rule.rs
+++ b/lib/src/statements/transaction/rule.rs
@@ -14,6 +14,7 @@ impl RuleBehaviour for Transaction {
                 self.description =
                     replace.0.replace_all(&self.description, with).to_string();
             }),
+            Action::AddItems { items } => Ok(self.items.extend(items.to_owned())),
         }
     }
 


### PR DESCRIPTION
This PR adds optional item lists to transactions. This allows for breaking up transactions into smaller parts and makes it easier for clients to track product price trends.